### PR TITLE
Add exceptions to max-len rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,12 @@ module.exports = {
     eqeqeq: "error",
     "guard-for-in": "error",
     "key-spacing": ["error", { beforeColon: false }],
-    "max-len": ["warn", 120],
+    "max-len": ["warn", 120, { 
+      ignoreStrings: true, 
+      ignoreTemplateLiterals: true,
+      ignoreUrls: true,
+      ignoreRegExpLiterals: true
+    }],
     "max-params": ["error", 4],
     "no-console": "off",
     "no-debugger": "warn",


### PR DESCRIPTION
Allow extra-long lines for URLs, strings, template literals, and regexes.

If anyone feels strongly that any of these cases shouldn't be ignored, let me know! I'm definitely open to being convinced.